### PR TITLE
Loosen up the warning filter regexp

### DIFF
--- a/lib/tool/warning_filter.rb
+++ b/lib/tool/warning_filter.rb
@@ -14,7 +14,7 @@ module Tool
 
     # @!visibility private
     def write(line)
-      super if line !~ /^\S+gems\/ruby\-\S+:\d+: warning:/
+      super if line !~ /^\S+gems?\/ruby\S+:\d+: warning:/
     end
   end
 end


### PR DESCRIPTION
Did not match my gems; installed with ruby-install:

```
/Users/jage/.gem/ruby/2.2.0/gems/sequel-4.15.0/lib/sequel/dataset/sql.rb:1467: warning: instance variable @skip_symbol_cache not initialized
/Users/jage/.gem/ruby/2.2.0/gems/sequel-4.15.0/lib/sequel/dataset/query.rb:78: warning: instance variable @columns not initialized
/Users/jage/.gem/ruby/2.2.0/gems/sequel-4.15.0/lib/sequel/dataset/sql.rb:1467: warning: instance variable @skip_symbol_cache not initialized
/Users/jage/.gem/ruby/2.2.0/gems/sequel-4.15.0/lib/sequel/dataset/query.rb:78: warning: instance variable @columns not initialized
/Users/jage/.gem/ruby/2.2.0/gems/sequel-4.15.0/lib/sequel/dataset/query.rb:78: warning: instance variable @columns not initialized
/Users/jage/.gem/ruby/2.2.0/gems/sequel-4.15.0/lib/sequel/dataset/query.rb:78: warning: instance variable @columns not initialized
```

Thanks for a great gem!